### PR TITLE
Use static url for bugtracker (GH #1) and additional meta resources.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -28,7 +28,12 @@ SQL::Translator = 0.11006
 [PruneFiles]
 [ReadmeMarkdownFromPod]
 [MetaResourcesFromGit]
-bugtracker.web = https://github.com/%a/%r/issues
+bugtracker.web  = https://github.com/mattp-/DBIx-Class-FilterColumn-ByType/issues
+repository.url  = git://github.com/mattp-/DBIx-Class-FilterColumn-ByType.git
+repository.web  = https://github.com/mattp-/DBIx-Class-FilterColumn-ByType
+repository.type = git
+x_IRC           = irc://irc.perl.org/#dbix-class
+x_WebIRC        = https://chat.mibbit.com/#dbix-class@irc.perl.org
 [MetaConfig]
 [PodWeaver]
 [Run::BeforeRelease]


### PR DESCRIPTION
Everything else than static meta resources in dist.ini is most likely fragile as we see in this module.
Also added additional meta resources.

